### PR TITLE
Disabled weekdays and holidays will not be calculated in Minimum Deli…

### DIFF
--- a/order-delivery-date-for-woocommerce/js/orddd-lite-initialize-datepicker.js
+++ b/order-delivery-date-for-woocommerce/js/orddd-lite-initialize-datepicker.js
@@ -71,13 +71,94 @@ function orddd_lite_autofil_date_time() {
     	delay_days.setDate( delay_days.getDate()+1 );
 	}
 	
-    if( delay_days != '' ) {
-		var min_date_to_set = delay_days.getDate() + "-" + ( delay_days.getMonth()+1 ) + "-" + delay_days.getFullYear();
-    }
-	
+	if( delay_date != "" ) {
+		delay_days = minimum_date_to_set( delay_days );
+        if( delay_days != '' ) {
+			var min_date_to_set = delay_days.getDate() + "-" + ( delay_days.getMonth()+1 ) + "-" + delay_days.getFullYear();
+        }
+	}
+
 	var date_to_set = delay_days;
 	jQuery( '#e_deliverydate' ).datepicker( "setDate", date_to_set );
 	jQuery( "#h_deliverydate" ).val( min_date_to_set );
+}
+
+function minimum_date_to_set( delay_days ) {
+	var disabledDays = eval( "[" + jQuery( "#orddd_lite_holidays" ).val() + "]" );
+	var holidays = [];
+	for ( i = 0; i < disabledDays.length; i++ ) {
+		var holidays_array = disabledDays[ i ].split( ":" );
+		holidays[i] = holidays_array[ 1 ];
+	}
+
+	var bookedDays = eval( "[" + jQuery( "#orddd_lite_lockout_days" ).val() + "]" );
+
+	var current_date = jQuery( "#orddd_lite_current_day" ).val();
+	var split_current_date = current_date.split( "-" );
+	var current_day = new Date ( split_current_date[ 1 ] + "/" + split_current_date[ 0 ] + "/" + split_current_date[ 2 ] );
+
+	var delay_time = delay_days.getTime();
+    var current_time = current_day.getTime();
+    var current_weekday = current_day.getDay();
+    
+	var j;
+	for ( j = current_weekday ; current_time <= delay_time ; j++ ) {
+		if( j >= 0 ) {
+			if ( jQuery( "#orddd_lite_calculate_min_time_disabled_days" ).val() != 'on' ) {
+				day = 'orddd_lite_weekday_' + current_weekday;
+				day_check = jQuery( "#" + day ).val();
+				if ( day_check == '' ) {
+					delay_days.setDate( delay_days.getDate()+1 );
+					delay_time = delay_days.getTime();
+					current_day.setDate( current_day.getDate()+1 );
+					current_time = current_day.getTime();
+					current_weekday = current_day.getDay();
+				} else {
+					if( current_day <= delay_days ) {
+						var m = current_day.getMonth(), d = current_day.getDate(), y = current_day.getFullYear();
+						if( jQuery.inArray( ( m+1 ) + '-' + d + '-' + y, holidays ) != -1 ) {	
+							delay_days.setDate( delay_days.getDate()+1 );
+							delay_time = delay_days.getTime();
+						}
+						current_day.setDate( current_day.getDate()+1 );
+						current_time = current_day.getTime();
+						current_weekday = current_day.getDay();
+					}
+				}
+			} else {
+				if( current_day <= delay_days ) {
+					var m = current_day.getMonth(), d = current_day.getDate(), y = current_day.getFullYear();
+					if( jQuery.inArray( ( m+1 ) + '-' + d + '-' + y, holidays ) != -1 ) {	
+						delay_days.setDate( delay_days.getDate()+1 );
+						delay_time = delay_days.getTime();
+					}
+					current_day.setDate( current_day.getDate()+1 );
+					current_time = current_day.getTime();
+					current_weekday = current_day.getDay();
+				}
+			}
+		} else {
+			break;
+		}
+	}
+	
+    if( delay_days != '' ) {
+    	for ( i = 0; i < holidays.length; i++ ) {
+	        var dm = delay_days.getMonth(), dd = delay_days.getDate(), dy = delay_days.getFullYear();
+	        if( jQuery.inArray( ( dm+1 ) + "-" + dd + "-" + dy, holidays ) != -1 ) {
+	            delay_days.setDate( delay_days.getDate()+1 );
+	            delay_time = delay_days.getTime();
+	        }
+	    }
+
+        var dm = delay_days.getMonth(), dd = delay_days.getDate(), dy = delay_days.getFullYear();
+        if( jQuery.inArray( ( dm+1 ) + "-" + dd + "-" + dy, bookedDays ) != -1 ) {
+            delay_days.setDate( delay_days.getDate()+1 );
+            delay_time = delay_days.getTime();
+        } 
+    }
+    
+	return delay_days;
 }
 
 function nd( date ) {
@@ -146,6 +227,52 @@ function avd( date ) {
 	}
 	if( isNaN( noOfDaysToFind ) ) {
 		noOfDaysToFind = 1000;
+	}
+	
+	if( delay_date != "" ) {
+		var delay_time = delay_days.getTime();
+		var current_time = current_day.getTime();
+		var current_weekday = current_day.getDay();
+		var j;
+		for ( j = current_weekday ; current_time <= delay_time ; j++ ) {
+			if( j >= 0 ) {
+				if ( jQuery( "#orddd_lite_calculate_min_time_disabled_days" ).val() != 'on' ) {
+					day = 'orddd_lite_weekday_' + current_weekday;
+					day_check = jQuery( "#" + day ).val();
+					if ( day_check == '' ) {
+						delay_days.setDate( delay_days.getDate()+1 );
+						delay_time = delay_days.getTime();
+						current_day.setDate( current_day.getDate()+1 );
+						current_time = current_day.getTime();
+						current_weekday = current_day.getDay();
+					} else {
+						if( current_day <= delay_days ) {
+							var m = current_day.getMonth(), d = current_day.getDate(), y = current_day.getFullYear();
+							if( jQuery.inArray( ( m+1 ) + '-' + d + '-' + y, holidays ) != -1 ) {	
+								delay_days.setDate( delay_days.getDate()+1 );
+								delay_time = delay_days.getTime();
+							}
+							current_day.setDate( current_day.getDate()+1 );
+							current_time = current_day.getTime();
+							current_weekday = current_day.getDay();
+						}
+					}
+				} else {
+					if( current_day <= delay_days ) {
+						var m = current_day.getMonth(), d = current_day.getDate(), y = current_day.getFullYear();
+						if( jQuery.inArray( ( m+1 ) + '-' + d + '-' + y, holidays ) != -1 ) {	
+							delay_days.setDate( delay_days.getDate()+1 );
+							delay_time = delay_days.getTime();
+						}
+						current_day.setDate( current_day.getDate()+1 );
+						current_time = current_day.getTime();
+						current_weekday = current_day.getDay();
+					}
+				}
+			} else {
+				break;
+			}
+		}
 	}
 
 	var minDate = delay_days;

--- a/order-delivery-date-for-woocommerce/orddd-lite-process.php
+++ b/order-delivery-date-for-woocommerce/orddd-lite-process.php
@@ -92,6 +92,8 @@ class orddd_lite_process{
 
             $var .= '<input type="hidden" name="orddd_lite_auto_populate_first_available_date" id="orddd_lite_auto_populate_first_available_date" value="' . get_option( 'orddd_lite_auto_populate_first_available_date' ) . '">';
 
+            $var .= '<input type="hidden" name="orddd_lite_calculate_min_time_disabled_days" id="orddd_lite_calculate_min_time_disabled_days" value="' . get_option( 'orddd_lite_calculate_min_time_disabled_days' ) . '">';
+
             $current_time = current_time( 'timestamp' );
 	    	$current_date = date( "j-n-Y", $current_time );
             $var .= '<input type="hidden" name="orddd_lite_current_day" id="orddd_lite_current_day" value="' . $current_date . '">';

--- a/order-delivery-date-for-woocommerce/orddd-lite-settings.php
+++ b/order-delivery-date-for-woocommerce/orddd-lite-settings.php
@@ -87,6 +87,15 @@ class orddd_lite_settings {
             array( __( 'Auto-populate first available Delivery date when the checkout page loads.', 'order-delivery-date' ) )
         );
 
+        add_settings_field(
+            'orddd_lite_calculate_min_time_disabled_days',
+            __( 'Apply Minimum Delivery Time for non working weekdays:', 'order-delivery-date' ),
+            array( 'orddd_lite_settings', 'orddd_lite_calculate_min_time_disabled_days_callback' ),
+            'orddd_lite_date_settings_page',
+            'orddd_lite_date_settings_section',
+            array( __( 'If selected, then the Minimum Delivery Time (in hours) will be applied on the non working weekdays which are unchecked in Delivery Weekdays. If unchecked, then it will not be applied. For example, if Minimum Delivery Time (in hours) is set to 48 hours and Saturday is disabled for delivery. Now if a customer visits the website on Firday, then the first available date will be Monday and not Sunday.', 'order-delivery-date' ) )
+        );
+
         foreach ( $orddd_lite_weekdays as $n => $day_name ) {
             register_setting(
                 'orddd_lite_date_settings',
@@ -127,6 +136,11 @@ class orddd_lite_settings {
         register_setting(
             'orddd_lite_date_settings',
             'orddd_lite_auto_populate_first_available_date'
+        );
+
+        register_setting(
+            'orddd_lite_date_settings',
+            'orddd_lite_calculate_min_time_disabled_days'
         );
     }
 
@@ -472,6 +486,17 @@ class orddd_lite_settings {
         echo $html;
     }
 
+    public static function orddd_lite_calculate_min_time_disabled_days_callback( $args ) {
+        $orddd_lite_calculate_min_time_disabled_days = '';
+        if ( get_option( 'orddd_lite_calculate_min_time_disabled_days' ) == 'on' ) {
+            $orddd_lite_calculate_min_time_disabled_days = "checked";
+        }
+        
+        echo '<input type="checkbox" name="orddd_lite_calculate_min_time_disabled_days" id="orddd_lite_calculate_min_time_disabled_days" class="day-checkbox" ' . $orddd_lite_calculate_min_time_disabled_days . '/>';
+        
+        $html = '<label for="orddd_lite_calculate_min_time_disabled_days"> '. $args[ 0 ] . '</label>';
+        echo $html;   
+    }
     /**
      * Callback for adding Appearance tab settings
      */


### PR DESCRIPTION
…very Time

Currently minimum delivery time in hours is applied on disabled weekdays by default. A setting is added named as 'Apply Minimum Delivery Time for non working weekdays' under Date settings tab. The default value of this checkbox will be on if plugin is updated else it will be off if installed for the first. And if this setting is on then the minimum delivery time will be applied on the disabled weekdays else not.

For holidays, no setting is added, the minimum delivery time will be not applied on holidays by default.