### PR TITLE
Version 2.8 final copy

### DIFF
--- a/order-delivery-date-for-woocommerce/order_delivery_date.php
+++ b/order-delivery-date-for-woocommerce/order_delivery_date.php
@@ -78,7 +78,7 @@ if ( !class_exists( 'order_delivery_date_lite' ) ) {
             add_action( 'wp_trash_post', array( 'orddd_lite_common', 'orddd_lite_cancel_delivery_for_trashed' ), 10, 1 );
         }
         
-         function orddd_lite_activate() {
+        function orddd_lite_activate() {
             global $orddd_lite_weekdays;
         
             add_option( 'orddd_lite_enable_delivery_date', '' );


### PR DESCRIPTION
* Feature - From now you can set holidays on the dates you do not deliver products under Holidays tab. Selected holidays will be disabled for delivery in the delivery calendar on the checkout page.

* Feature - A new checkbox named 'Auto-populate first available Delivery date' is added in Date Settings tab. If this checkbox is enabled then the first available Delivery Date will be Auto-populated in the Delivery Date field on the Checkout Page.

* Feature - A new checkbox named 'Apply Minimum Delivery Time for non-working weekdays' is added under Date Settings tab. If this checkbox is checked then the Minimum Delivery Time (in hours) will be calculated on the non-working days which are unchecked under Delivery Days. If the checkbox is unchecked then the minimum delivery time will be calculated on the working days. The default value of the checkbox is checked when the plugin is updated.