### PR TITLE
Version 2.9

### DIFF
--- a/order-delivery-date-for-woocommerce/order_delivery_date.php
+++ b/order-delivery-date-for-woocommerce/order_delivery_date.php
@@ -4,12 +4,12 @@ Plugin Name: Order Delivery Date for WooCommerce (Lite version)
 Plugin URI: http://www.tychesoftwares.com/store/free-plugin/order-delivery-date-on-checkout/
 Description: This plugin allows customers to choose their preferred Order Delivery Date during checkout.
 Author: Tyche Softwares
-Version: 2.8
+Version: 2.9
 Author URI: http://www.tychesoftwares.com/about
 Contributor: Tyche Softwares, http://www.tychesoftwares.com/
 */
 
-$wpefield_version = '2.8';
+$wpefield_version = '2.9';
 
 include_once( 'integration.php' );
 include_once( 'orddd-lite-config.php' );
@@ -221,7 +221,7 @@ if ( !class_exists( 'order_delivery_date_lite' ) ) {
         function orddd_lite_update_db_check() {
             global $orddd_lite_plugin_version, $wpefield_version;
             $orddd_lite_plugin_version = $wpefield_version;
-            if ( $orddd_lite_plugin_version == "2.8" ) {
+            if ( $orddd_lite_plugin_version == "2.9" ) {
                 order_delivery_date_lite::orddd_lite_update_install();
             }
         }
@@ -232,7 +232,7 @@ if ( !class_exists( 'order_delivery_date_lite' ) ) {
             //code to set the option to on as default
             $orddd_lite_plugin_version = get_option( 'orddd_lite_db_version' );
             if ( $orddd_lite_plugin_version != order_delivery_date_lite::get_orddd_lite_version() ) {
-                update_option( 'orddd_lite_db_version', '2.8' );
+                update_option( 'orddd_lite_db_version', '2.9' );
                 if ( get_option( 'orddd_lite_update_value' ) != 'yes' ) {
                     $i = 0;
                     foreach ( $orddd_lite_weekdays as $n => $day_name ) {

--- a/order-delivery-date-for-woocommerce/readme.txt
+++ b/order-delivery-date-for-woocommerce/readme.txt
@@ -6,7 +6,7 @@ Tested up to: 4.7.3
 Stable tag: trunk
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
-Donate link: http://www.tychesoftwares.com/
+Donate link: https://www.paypal.me/TycheSoftwares
 
 Allow the customers to choose an order delivery date on the checkout page for WooCommerce store owners.
 
@@ -95,6 +95,10 @@ The field can be configured as Mandatory or optional using the 'Mandatory field?
 3. Delivery Date will be displayed on the Orders page in a new column titled "Delivery Date".
 
 == Changelog ==
+
+= 2.9 =
+
+* Fix - Warnings were displayed on the Order Received page with WooCommerce version 3.0.0. This is fixed now.
 
 = 2.8 =
 


### PR DESCRIPTION
= 2.9 =

* Fix - Warnings were displayed on the Order Received page with WooCommerce version 3.0.0. This is fixed now.