### PR TITLE
Fix #46

### DIFF
--- a/order-delivery-date-for-woocommerce/js/orddd-lite-initialize-datepicker.js
+++ b/order-delivery-date-for-woocommerce/js/orddd-lite-initialize-datepicker.js
@@ -225,7 +225,7 @@ function avd( date ) {
 		delay_days.setDate( delay_days.getDate()+1 );
 	
 	}
-	if( isNaN( noOfDaysToFind ) ) {
+	if( isNaN( noOfDaysToFind ) || 0 === noOfDaysToFind ) {
 		noOfDaysToFind = 1000;
 	}
 	


### PR DESCRIPTION
Date picker was not working when the Number of dates to choose is set to 0. This is fixed now.