### PR TITLE
Version 3.1

### DIFF
--- a/order-delivery-date-for-woocommerce/order_delivery_date.php
+++ b/order-delivery-date-for-woocommerce/order_delivery_date.php
@@ -4,12 +4,12 @@ Plugin Name: Order Delivery Date for WooCommerce (Lite version)
 Plugin URI: http://www.tychesoftwares.com/store/free-plugin/order-delivery-date-on-checkout/
 Description: This plugin allows customers to choose their preferred Order Delivery Date during checkout.
 Author: Tyche Softwares
-Version: 3.0
+Version: 3.1
 Author URI: http://www.tychesoftwares.com/about
 Contributor: Tyche Softwares, http://www.tychesoftwares.com/
 */
 
-$wpefield_version = '3.0';
+$wpefield_version = '3.1';
 
 include_once( 'integration.php' );
 include_once( 'orddd-lite-config.php' );
@@ -242,7 +242,7 @@ if ( !class_exists( 'order_delivery_date_lite' ) ) {
         function orddd_lite_update_db_check() {
             global $orddd_lite_plugin_version, $wpefield_version;
             $orddd_lite_plugin_version = $wpefield_version;
-            if ( $orddd_lite_plugin_version == "3.0" ) {
+            if ( $orddd_lite_plugin_version == "3.1" ) {
                 order_delivery_date_lite::orddd_lite_update_install();
             }
         }
@@ -253,7 +253,7 @@ if ( !class_exists( 'order_delivery_date_lite' ) ) {
             //code to set the option to on as default
             $orddd_lite_plugin_version = get_option( 'orddd_lite_db_version' );
             if ( $orddd_lite_plugin_version != order_delivery_date_lite::get_orddd_lite_version() ) {
-                update_option( 'orddd_lite_db_version', '3.0' );
+                update_option( 'orddd_lite_db_version', '3.1' );
                 if ( get_option( 'orddd_lite_update_value' ) != 'yes' ) {
                     $i = 0;
                     foreach ( $orddd_lite_weekdays as $n => $day_name ) {

--- a/order-delivery-date-for-woocommerce/readme.txt
+++ b/order-delivery-date-for-woocommerce/readme.txt
@@ -196,6 +196,10 @@ You can refer **[here](https://www.tychesoftwares.com/differences-pro-lite-versi
 6. Holidays tab
 
 == Changelog ==
+= 3.1 (19.07.2017) =
+
+* You can add the Delivery Date field on the WooCommerce Cart page along with the Checkout page. A checkbox is added for this under Appearance tab.
+* The selected Delivery Date will be retained until the order is placed.
 
 = 3.0 (06.07.2017) =
 


### PR DESCRIPTION
= 3.1 (19.07.2017) =

* You can add the Delivery Date field on the WooCommerce Cart page along with the Checkout page. A checkbox is added for this under Appearance tab.

* The selected Delivery Date will be retained until the order is placed.