### PR TITLE
Version 3.3

### DIFF
--- a/order-delivery-date-for-woocommerce/order_delivery_date.php
+++ b/order-delivery-date-for-woocommerce/order_delivery_date.php
@@ -4,12 +4,12 @@ Plugin Name: Order Delivery Date for WooCommerce (Lite version)
 Plugin URI: http://www.tychesoftwares.com/store/free-plugin/order-delivery-date-on-checkout/
 Description: This plugin allows customers to choose their preferred Order Delivery Date during checkout.
 Author: Tyche Softwares
-Version: 3.2
+Version: 3.3
 Author URI: http://www.tychesoftwares.com/about
 Contributor: Tyche Softwares, http://www.tychesoftwares.com/
 */
 
-$wpefield_version = '3.2';
+$wpefield_version = '3.3';
 
 include_once( 'integration.php' );
 include_once( 'orddd-lite-config.php' );
@@ -216,7 +216,7 @@ if ( !class_exists( 'order_delivery_date_lite' ) ) {
         function orddd_lite_update_db_check() {
             global $orddd_lite_plugin_version, $wpefield_version;
             $orddd_lite_plugin_version = $wpefield_version;
-            if ( $orddd_lite_plugin_version == "3.2" ) {
+            if ( $orddd_lite_plugin_version == "3.3" ) {
                 order_delivery_date_lite::orddd_lite_update_install();
             }
         }
@@ -227,7 +227,7 @@ if ( !class_exists( 'order_delivery_date_lite' ) ) {
             //code to set the option to on as default
             $orddd_lite_plugin_version = get_option( 'orddd_lite_db_version' );
             if ( $orddd_lite_plugin_version != order_delivery_date_lite::get_orddd_lite_version() ) {
-                update_option( 'orddd_lite_db_version', '3.2' );
+                update_option( 'orddd_lite_db_version', '3.3' );
                 if ( get_option( 'orddd_lite_update_value' ) != 'yes' ) {
                     $i = 0;
                     foreach ( $orddd_lite_weekdays as $n => $day_name ) {

--- a/order-delivery-date-for-woocommerce/readme.txt
+++ b/order-delivery-date-for-woocommerce/readme.txt
@@ -216,6 +216,12 @@ You can refer **[here](https://www.tychesoftwares.com/differences-pro-lite-versi
 6. Holidays tab
 
 == Changelog ==
+= 3.3 (28.12.2017) =
+
+* The delivery date field label was not coming properly on the checkout page. This is fixed now.
+* Delivery weekdays were not getting deleted when the plugin is deleted. This is fixed now. 
+* Some errors in the debug.log file are fixed. 
+
 = 3.2 (06.09.2017) =
 
 * A new language 'Persian' is added for the calendar. Now you can set your Delivery Calendar in the Persian language on the Checkout Page.
@@ -357,6 +363,12 @@ Note: Please take a back up before updating this version.
 * Initial release.
 
 == Upgrade Notice ==
+= 3.3 (28.12.2017) =
+
+* The delivery date field label was not coming properly on the checkout page. This is fixed now.
+* Delivery weekdays were not getting deleted when the plugin is deleted. This is fixed now. 
+* Some errors in the debug.log file are fixed. 
+
 = 3.2 (06.09.2017) =
 
 * A new language 'Persian' is added for the calendar. Now you can set your Delivery Calendar in the Persian language on the Checkout Page.


### PR DESCRIPTION
= 3.3 (28.12.2017) =

* The delivery date field label was not coming properly on the checkout page. This is fixed now.

* Delivery weekdays were not getting deleted when the plugin is deleted. This is fixed now.

* Some errors in the debug.log file are fixed.