### PR TITLE
Fix #55

### DIFF
--- a/order-delivery-date-for-woocommerce/order_delivery_date.php
+++ b/order-delivery-date-for-woocommerce/order_delivery_date.php
@@ -111,6 +111,7 @@ if ( !class_exists( 'order_delivery_date_lite' ) ) {
             add_option( 'orddd_lite_default_appearance_settings', 'yes' );
             add_option( 'orddd_lite_enable_default_sorting_of_column', '' );
             add_option( 'orddd_lite_enable_delivery_date_enabled', 'yes' );
+            add_option( 'orddd_lite_auto_populate_first_available_date', 'on' );
             
             // appearance options
             add_option( 'orddd_lite_delivery_date_format', ORDDD_LITE_DELIVERY_DATE_FORMAT );


### PR DESCRIPTION
From now, the default value of Auto-populate first available Delivery date setting will be set to 'on' now. This is fixed now.