### PR TITLE
Fix 115

### DIFF
--- a/order-delivery-date-for-woocommerce/js/orddd-lite-initialize-datepicker.js
+++ b/order-delivery-date-for-woocommerce/js/orddd-lite-initialize-datepicker.js
@@ -191,25 +191,15 @@ function minimum_date_to_set( delay_days ) {
 					}
 				}
 			} else {
-				day = 'orddd_lite_weekday_' + current_weekday;
-				day_check = jQuery( "#" + day ).val();
-				if ( day_check == '' ) {
-					delay_days.setDate( delay_days.getDate()+1 );
-					delay_time = delay_days.getTime();
+				if( current_day <= delay_days ) {
+					var m = current_day.getMonth(), d = current_day.getDate(), y = current_day.getFullYear();
+					if( jQuery.inArray( ( m+1 ) + '-' + d + '-' + y, holidays ) != -1 ) {	
+						delay_days.setDate( delay_days.getDate()+1 );
+						delay_time = delay_days.getTime();
+					}
 					current_day.setDate( current_day.getDate()+1 );
 					current_time = current_day.getTime();
 					current_weekday = current_day.getDay();
-				} else {
-					if( current_day <= delay_days ) {
-						var m = current_day.getMonth(), d = current_day.getDate(), y = current_day.getFullYear();
-						if( jQuery.inArray( ( m+1 ) + '-' + d + '-' + y, holidays ) != -1 ) {	
-							delay_days.setDate( delay_days.getDate()+1 );
-							delay_time = delay_days.getTime();
-						}
-						current_day.setDate( current_day.getDate()+1 );
-						current_time = current_day.getTime();
-						current_weekday = current_day.getDay();
-					}
 				}
 			}
 		} else {


### PR DESCRIPTION
Auto populate was not calculating on the non working days when 'Apply Minimum Delivery Time for non working weekdays' setting was enabled. This is fixed now.