### PR TITLE
We do not track any data when selected No for tracking

### DIFF
--- a/order-delivery-date-for-woocommerce/includes/component/tracking data/class-ts-tracker.php
+++ b/order-delivery-date-for-woocommerce/includes/component/tracking data/class-ts-tracker.php
@@ -78,7 +78,7 @@ class TS_Tracker {
 			$params   = array();
 			$params[ 'tracking_usage' ] = 'no';
 			$params[ 'url' ]            = home_url();
-			$params[ 'email' ]          = apply_filters( 'ts_tracker_admin_email', get_option( 'admin_email' ) );
+			$params[ 'email' ]          = '';
 			
 			$params 					= apply_filters( 'ts_tracker_opt_out_data', $params );
 		} else {

--- a/order-delivery-date-for-woocommerce/orddd-lite-common.php
+++ b/order-delivery-date-for-woocommerce/orddd-lite-common.php
@@ -29,8 +29,6 @@ class orddd_lite_common {
 	    $plugin_data[ 'ts_meta_data_table_name']   = 'ts_tracking_orddd_lite_meta_data';
 	    $plugin_data[ 'ts_plugin_name' ]		   = 'Order Delivery Date for WooCommerce (Lite version)';
 	    
-	    // Store count info
-	    $plugin_data[ 'deliveries_count' ]         = self::orddd_lite_ts_get_order_counts();
 	    $params[ 'plugin_data' ]  				   = $plugin_data;
 	    
 	    return $params;
@@ -50,7 +48,6 @@ class orddd_lite_common {
     public static function orddd_lite_ts_add_plugin_tracking_data ( $data ) {
     	if ( isset( $_GET[ 'orddd_lite_tracker_optin' ] ) && isset( $_GET[ 'orddd_lite_tracker_nonce' ] ) && wp_verify_nonce( $_GET[ 'orddd_lite_tracker_nonce' ], 'orddd_lite_tracker_optin' ) ) {
 
-	        $plugin_data  = array();
 	        $plugin_data[ 'ts_meta_data_table_name' ]   = 'ts_tracking_orddd_lite_meta_data';
 	        $plugin_data[ 'ts_plugin_name' ]		    = 'Order Delivery Date for WooCommerce (Lite version)';
 	        


### PR DESCRIPTION
When select No for the tracking we send the admin email along with some delivery data.

Now, we do capture admin email and do not send any delivery data.