### PR TITLE
Version 3.5

### DIFF
--- a/order-delivery-date-for-woocommerce/order_delivery_date.php
+++ b/order-delivery-date-for-woocommerce/order_delivery_date.php
@@ -4,7 +4,7 @@ Plugin Name: Order Delivery Date for WooCommerce (Lite version)
 Plugin URI: https://www.tychesoftwares.com/store/premium-plugins/order-delivery-date-for-woocommerce-pro-21/
 Description: This plugin allows customers to choose their preferred Order Delivery Date during checkout.
 Author: Tyche Softwares
-Version: 3.4.2
+Version: 3.5
 Author URI: https://www.tychesoftwares.com/
 Contributor: Tyche Softwares, http://www.tychesoftwares.com/
 Text Domain: order-delivery-date
@@ -18,7 +18,7 @@ WC tested up to: 3.3.0
  * Latest version of the plugin
  * @since 1.0
  */
-$wpefield_version = '3.4.2';
+$wpefield_version = '3.5';
 
 /**
  * Include the require files
@@ -289,7 +289,7 @@ if ( !class_exists( 'order_delivery_date_lite' ) ) {
         
         function orddd_lite_update_db_check() {
             global $wpefield_version;
-            if ( $wpefield_version == "3.4.2" ) {
+            if ( $wpefield_version == "3.5" ) {
                 order_delivery_date_lite::orddd_lite_update_install();
             }
         }
@@ -307,7 +307,7 @@ if ( !class_exists( 'order_delivery_date_lite' ) ) {
             //code to set the option to on as default
             $orddd_lite_plugin_version = get_option( 'orddd_lite_db_version' );
             if ( $orddd_lite_plugin_version != order_delivery_date_lite::get_orddd_lite_version() ) {
-                update_option( 'orddd_lite_db_version', '3.4.2' );
+                update_option( 'orddd_lite_db_version', '3.5' );
                 if ( get_option( 'orddd_lite_update_value' ) != 'yes' ) {
                     $i = 0;
                     foreach ( $orddd_lite_weekdays as $n => $day_name ) {

--- a/order-delivery-date-for-woocommerce/readme.txt
+++ b/order-delivery-date-for-woocommerce/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://www.paypal.me/TycheSoftwares
 Author URI: https://www.tychesoftwares.com/
 Tags: delivery date, order delivery date, woocommerce delivery date, delivery, order delivery
 Requires at least: 1.3
-Tested up to: 4.9.2
+Tested up to: 4.9.6
 Stable tag: trunk
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -216,6 +216,13 @@ You can refer **[here](https://www.tychesoftwares.com/differences-pro-lite-versi
 6. Holidays tab
 
 == Changelog ==
+= 3.5 (23.05.2018) =
+
+* The plugin is now GDPR compliant.
+* Delivery Date & Time for the orders will now be exported to the User's Personal Data from the Tools -> Export Personal Data menu.
+* A warning was displayed on the checkout page when Minimum delivery time is set to blank. This is fixed now.
+* Some notices are fixed in debug.log file.
+
 = 3.4.2 (22.02.2018) =
 
 * Additional columns "Fecha Horneada" and "Encargado" were added on the WooCommerce Edit order page when the plugin is updated to version 3.4.1. 
@@ -382,6 +389,13 @@ Note: Please take a back up before updating this version.
 * Initial release.
 
 == Upgrade Notice ==
+= 3.5 (23.05.2018) =
+
+* The plugin is now GDPR compliant.
+* Delivery Date & Time for the orders will now be exported to the User's Personal Data from the Tools -> Export Personal Data menu.
+* A warning was displayed on the checkout page when Minimum delivery time is set to blank. This is fixed now.
+* Some notices are fixed in debug.log file.
+
 = 3.4.2 (22.02.2018) =
 
 * Additional columns "Fecha Horneada" and "Encargado" were added on the WooCommerce Edit order page when the plugin is updated to version 3.4.1. 


### PR DESCRIPTION
= 3.5 (23.05.2018) =

* The plugin is now GDPR compliant.

* Delivery Date & Time for the orders will now be exported to the User's Personal Data from the Tools -> Export Personal Data menu.

* A warning was displayed on the checkout page when Minimum delivery time is set to blank. This is fixed now.

* Some notices are fixed in debug.log file.