### PR TITLE
Fix #118

### DIFF
--- a/order-delivery-date-for-woocommerce/js/orddd-lite-initialize-datepicker.js
+++ b/order-delivery-date-for-woocommerce/js/orddd-lite-initialize-datepicker.js
@@ -191,6 +191,13 @@ function minimum_date_to_set( delay_days ) {
 					}
 				}
 			} else {
+				day = 'orddd_lite_weekday_' + delay_days.getDay();
+				day_check = jQuery( "#" + day ).val();
+				if ( day_check == '' ) {
+					delay_days.setDate( delay_days.getDate()+1 );
+					delay_time = delay_days.getTime();					
+				}
+
 				if( current_day <= delay_days ) {
 					var m = current_day.getMonth(), d = current_day.getDate(), y = current_day.getFullYear();
 					if( jQuery.inArray( ( m+1 ) + '-' + d + '-' + y, holidays ) != -1 ) {	


### PR DESCRIPTION
Wrong delivery date was auto-populated when the first available delivery date is set to holiday. This is fixed now.