### PR TITLE
Fix #103

### DIFF
--- a/order-delivery-date-for-woocommerce/orddd-lite-settings.php
+++ b/order-delivery-date-for-woocommerce/orddd-lite-settings.php
@@ -1054,7 +1054,7 @@ class orddd_lite_settings {
                     update_option( 'orddd_lite_holidays', $holidays_jarr );                
                 }
             } 
-            wp_safe_redirect( esc_url( admin_url( '/admin.php?page=order_delivery_date_lite&action=holidays' ) ) );
+            wp_safe_redirect( admin_url( '/admin.php?page=order_delivery_date_lite&action=holidays' ) );
         }
     }
 }


### PR DESCRIPTION
After deleting the holidays from the Holidays tab, the page was redirected to the Date Settings tab whereas it should stay on Holidays page itself. This is fixed now.