### PR TITLE
Fix #150

### DIFF
--- a/order-delivery-date-for-woocommerce/js/orddd-lite-initialize-datepicker.js
+++ b/order-delivery-date-for-woocommerce/js/orddd-lite-initialize-datepicker.js
@@ -366,16 +366,7 @@ function avd( date ) {
 						}
 					}
 				} else {
-					if( current_day <= delay_days ) {
-						var m = current_day.getMonth(), d = current_day.getDate(), y = current_day.getFullYear();
-						if( jQuery.inArray( ( m+1 ) + '-' + d + '-' + y, holidays ) != -1 ) {	
-							delay_days.setDate( delay_days.getDate()+1 );
-							delay_time = delay_days.getTime();
-						}
-						current_day.setDate( current_day.getDate()+1 );
-						current_time = current_day.getTime();
-						current_weekday = current_day.getDay();
-					}
+					break;
 				}
 			} else {
 				break;


### PR DESCRIPTION
Minimum Delivery time was not calculating on holidays when 'Apply Minimum Delivery Time for non working weekdays' option is enabled. This is fixed now.