### PR TITLE
Fix #158

### DIFF
--- a/order-delivery-date-for-woocommerce/js/orddd-lite-initialize-datepicker.js
+++ b/order-delivery-date-for-woocommerce/js/orddd-lite-initialize-datepicker.js
@@ -187,6 +187,11 @@ function minimum_date_to_set( delay_days ) {
 								delay_time = delay_days.getTime();
 							}
 						}
+
+						if( jQuery.inArray( ( m+1 ) + "-" + d + "-" + y, bookedDays ) != -1 ) {
+				            delay_days.setDate( delay_days.getDate()+1 );
+				            delay_time = delay_days.getTime();
+				        } 
 						current_day.setDate( current_day.getDate()+1 );
 						current_time = current_day.getTime();
 						current_weekday = current_day.getDay();
@@ -208,6 +213,12 @@ function minimum_date_to_set( delay_days ) {
 							delay_time = delay_days.getTime();
 						}
 					}
+
+					if( jQuery.inArray( ( m+1 ) + "-" + d + "-" + y, bookedDays ) != -1 ) {
+			            delay_days.setDate( delay_days.getDate()+1 );
+			            delay_time = delay_days.getTime();
+			        } 
+
 					current_day.setDate( current_day.getDate()+1 );
 					current_time = current_day.getTime();
 					current_weekday = current_day.getDay();


### PR DESCRIPTION
Incorrect delivery date is selected on the checkout page when the first available delivery date is booked and next available delivery date is disable in the calendar.