### PR TITLE
Version 3.7

### DIFF
--- a/order-delivery-date-for-woocommerce/order_delivery_date.php
+++ b/order-delivery-date-for-woocommerce/order_delivery_date.php
@@ -4,13 +4,13 @@ Plugin Name: Order Delivery Date for WooCommerce (Lite version)
 Plugin URI: https://www.tychesoftwares.com/store/premium-plugins/order-delivery-date-for-woocommerce-pro-21/
 Description: This plugin allows customers to choose their preferred Order Delivery Date during checkout.
 Author: Tyche Softwares
-Version: 3.6.1
+Version: 3.7
 Author URI: https://www.tychesoftwares.com/
 Contributor: Tyche Softwares, http://www.tychesoftwares.com/
 Text Domain: order-delivery-date
 Requires PHP: 5.6
 WC requires at least: 3.0.0
-WC tested up to: 3.5.4
+WC tested up to: 3.5.7
 * @package  Order-Delivery-Date-Lite-for-WooCommerce
 */
 
@@ -18,7 +18,7 @@ WC tested up to: 3.5.4
  * Latest version of the plugin
  * @since 1.0
  */
-$wpefield_version = '3.6.1';
+$wpefield_version = '3.7';
 
 /**
  * Include the require files
@@ -255,7 +255,7 @@ if ( !class_exists( 'order_delivery_date_lite' ) ) {
         
         function orddd_lite_update_db_check() {
             global $wpefield_version;
-            if ( $wpefield_version == "3.6.1" ) {
+            if ( $wpefield_version == "3.7" ) {
                 order_delivery_date_lite::orddd_lite_update_install();
             }
         }
@@ -273,7 +273,7 @@ if ( !class_exists( 'order_delivery_date_lite' ) ) {
             //code to set the option to on as default
             $orddd_lite_plugin_version = get_option( 'orddd_lite_db_version' );
             if ( $orddd_lite_plugin_version != order_delivery_date_lite::get_orddd_lite_version() ) {
-                update_option( 'orddd_lite_db_version', '3.6.1' );
+                update_option( 'orddd_lite_db_version', '3.7' );
                 if ( get_option( 'orddd_lite_update_value' ) != 'yes' ) {
                     $i = 0;
                     foreach ( $orddd_lite_weekdays as $n => $day_name ) {

--- a/order-delivery-date-for-woocommerce/readme.txt
+++ b/order-delivery-date-for-woocommerce/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://www.paypal.me/TycheSoftwares
 Author URI: https://www.tychesoftwares.com/
 Tags: delivery date, order delivery date, woocommerce delivery date, delivery, order delivery
 Requires at least: 1.3
-Tested up to: 5.0.3
+Tested up to: 5.1.1
 Stable tag: trunk
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -217,6 +217,17 @@ You can refer **[here](https://www.tychesoftwares.com/differences-pro-lite-versi
 6. Holidays tab
 
 == Changelog ==
+
+= 3.7 (04.04.2019) =
+
+There are some bug fixes in this update:
+* Incorrect delivery date was preselected in the delivery calendar on the checkout page when the current date is set as a holiday. This is fixed now. 
+* Preview calendar width was not coming proper on the Appearance link in Order Delivery Date -> Settings when the Eggplant calendar theme was selected. This is fixed now. 
+* Incorrect delivery date was preselected in the delivery calendar on the checkout page when the available dates have booked dates in between along with some weekdays disabled. This is fixed now. 
+* Incorrect delivery date was preselected on the checkout page due to the delivery date being stored in the session. This is fixed now. 
+* Width of the Delivery date field on the cart page was not proper. This is fixed now. 
+* On changing the first day of the week from Appearance link, the changes were not reflected in the admin calendars from the plugin. This is fixed now. 
+* WooCommerce Orders are not sorted in the descending order when "Sort on WooCommerce Orders Page" option is checked. This is fixed now. 
 
 = 3.6.1 (14.02.2019) =
 


### PR DESCRIPTION
There are some bug fixes in this update:
* Incorrect delivery date was preselected in the delivery calendar on the checkout page when the current date is set as a holiday. This is fixed now.
* Preview calendar width was not coming proper on the Appearance link in Order Delivery Date -> Settings when the Eggplant calendar theme was selected. This is fixed now.
* Incorrect delivery date was preselected in the delivery calendar on the checkout page when the available dates have booked dates in between along with some weekdays disabled. This is fixed now.
* Incorrect delivery date was preselected on the checkout page due to the delivery date being stored in the session. This is fixed now.
* Width of the Delivery date field on the cart page was not proper. This is fixed now.
* On changing the first day of the week from Appearance link, the changes were not reflected in the admin calendars from the plugin. This is fixed now.
* WooCommerce Orders are not sorted in the descending order when "Sort on WooCommerce Orders Page" option is checked. This is fixed now.