### PR TITLE
Fix #193

### DIFF
--- a/order-delivery-date-for-woocommerce/order_delivery_date.php
+++ b/order-delivery-date-for-woocommerce/order_delivery_date.php
@@ -313,18 +313,18 @@ if ( !class_exists( 'order_delivery_date_lite' ) ) {
             }
             
             wp_dequeue_script( 'themeswitcher' );
-            wp_enqueue_script( 'themeswitcher-orddd', esc_url( plugins_url( '/js/jquery.themeswitcher.min.js', __FILE__ ) ), array( 'jquery', 'jquery-ui-sortable', 'jquery-ui-datepicker' ), $wpefield_version, false );
+            wp_enqueue_script( 'themeswitcher-orddd', plugins_url( '/js/jquery.themeswitcher.min.js', __FILE__ ), array( 'jquery', 'jquery-ui-sortable', 'jquery-ui-datepicker' ), $wpefield_version, false );
                 
             foreach ( $orddd_lite_languages as $key => $value ) {
-                wp_enqueue_script( $value, esc_url( plugins_url( "/js/i18n/jquery.ui.datepicker-$key.js", __FILE__ ) ), array( 'jquery', 'jquery-ui-datepicker' ), $wpefield_version, false );
+                wp_enqueue_script( $value, plugins_url( "/js/i18n/jquery.ui.datepicker-$key.js", __FILE__ ), array( 'jquery', 'jquery-ui-datepicker' ), $wpefield_version, false );
             }
             
-            wp_register_style( 'woocommerce_admin_styles', esc_url( plugins_url() . '/woocommerce/assets/css/admin.css' ), array(), WC_VERSION );
+            wp_register_style( 'woocommerce_admin_styles', plugins_url() . '/woocommerce/assets/css/admin.css', array(), WC_VERSION );
             wp_enqueue_style( 'woocommerce_admin_styles' );
-            wp_enqueue_style( 'order-delivery-date', esc_url( plugins_url('/css/order-delivery-date.css', __FILE__ ) ) , '', $wpefield_version, false);
-            wp_register_style( 'jquery-ui-style', esc_url( plugins_url( '/css/themes/smoothness/jquery-ui.css', __FILE__ ) ), '', $wpefield_version, false );
+            wp_enqueue_style( 'order-delivery-date', plugins_url('/css/order-delivery-date.css', __FILE__ ), '', $wpefield_version, false);
+            wp_register_style( 'jquery-ui-style', plugins_url( '/css/themes/smoothness/jquery-ui.css', __FILE__ ), '', $wpefield_version, false );
             wp_enqueue_style( 'jquery-ui-style' );
-            wp_enqueue_style( 'datepicker', esc_url( plugins_url('/css/datepicker.css', __FILE__) ), '', $wpefield_version, false);            
+            wp_enqueue_style( 'datepicker', plugins_url('/css/datepicker.css', __FILE__), '', $wpefield_version, false);            
         }
         
         /**
@@ -358,12 +358,12 @@ if ( !class_exists( 'order_delivery_date_lite' ) ) {
                     $calendar_theme = 'base';
                 }
                 wp_dequeue_style( 'jquery-ui-style' );
-                wp_register_style( 'jquery-ui-style-orddd-lite', esc_url( plugins_url( '/css/themes/' . $calendar_theme . '/jquery-ui.css', __FILE__ ) ), '', $wpefield_version, false );
+                wp_register_style( 'jquery-ui-style-orddd-lite', plugins_url( '/css/themes/' . $calendar_theme . '/jquery-ui.css', __FILE__ ), '', $wpefield_version, false );
                 wp_enqueue_style( 'jquery-ui-style-orddd-lite' );
-                wp_enqueue_style( 'datepicker', esc_url( plugins_url('/css/datepicker.css', __FILE__) ), '', $wpefield_version, false);
+                wp_enqueue_style( 'datepicker', plugins_url('/css/datepicker.css', __FILE__), '', $wpefield_version, false);
                 
                 wp_dequeue_script( 'initialize-datepicker' );
-                wp_enqueue_script( 'initialize-datepicker-orddd', esc_url( plugins_url( '/js/orddd-lite-initialize-datepicker.js', __FILE__ ) ), '', $wpefield_version, false );
+                wp_enqueue_script( 'initialize-datepicker-orddd', plugins_url( '/js/orddd-lite-initialize-datepicker.js', __FILE__ ), '', $wpefield_version, false );
                 
                 $jsArgs = array(
                         'clearText'    => __( 'Clear', 'order-delivery-date' ),
@@ -391,7 +391,7 @@ if ( !class_exists( 'order_delivery_date_lite' ) ) {
                     }
                 }
                  
-                wp_enqueue_script( $language_selected, esc_url( plugins_url( "/js/i18n/jquery.ui.datepicker-$language_selected.js", __FILE__ ) ), array( 'jquery', 'jquery-ui-datepicker' ), $wpefield_version, false );
+                wp_enqueue_script( $language_selected, plugins_url( "/js/i18n/jquery.ui.datepicker-$language_selected.js", __FILE__ ), array( 'jquery', 'jquery-ui-datepicker' ), $wpefield_version, false );
             }
         }
 


### PR DESCRIPTION
Calendar is not working on the checkout page with the Prohauz Child theme due to custom code they have added to add defer onload in the js files while including them.

// Defer Javascripts
// Defer jQuery Parsing using the HTML5 defer property
if (!(is_admin() )) {
    function defer_parsing_of_js ( $url ) {
        if ( FALSE === strpos( $url, '.js' ) ) return $url;
        if ( strpos( $url, 'jquery.js' ) ) return $url;
        // return "$url' defer ";
        return "$url' defer onload='";
    }
    add_filter( 'clean_url', 'defer_parsing_of_js', 11, 1 );
}

The issue was due to the esc_url function we were using in wp_enqueue_scripts. And as we don't need to use esc_url in the wp_enqueue_scripts function we are removing it.