### PR TITLE
Fix #192

### DIFF
--- a/order-delivery-date-for-woocommerce/js/orddd-lite-initialize-datepicker.js
+++ b/order-delivery-date-for-woocommerce/js/orddd-lite-initialize-datepicker.js
@@ -538,7 +538,7 @@ function gd( date1, date2, interval ) {
 		case "weeks":
 			return Math.floor( timediff / week );
 		case "days":
-			return Math.floor( timediff / day );
+			return Math.floor( timediff / day ) + 1;
 		case "hours":
 			return Math.floor( timediff / hour );
 		case "minutes":


### PR DESCRIPTION
One day less is available in the calendar on the checkout page when Minimum Delivery Time is set, Number of dates to choose is set to 3 and current weekday is disabled.