### PR TITLE
Fix #199

### DIFF
--- a/order-delivery-date-for-woocommerce/includes/settings/orddd-lite-calendar-sync-settings.php
+++ b/order-delivery-date-for-woocommerce/includes/settings/orddd-lite-calendar-sync-settings.php
@@ -166,15 +166,6 @@ class orddd_lite_calendar_sync_settings {
         $html = '<label for="orddd_lite_calendar_id"> ' . $args[0] . '</label>';
         echo $html;
     }
-
-    /**
-     * Callback for adding the 'Test Connection' link and checks if the connection is succesful or not
-     *
-     * @since 3.9
-     */
-    public static function orddd_lite_calendar_test_connection_callback() {
-        print "<a href='admin.php?page=order_delivery_date&action=calendar_sync_settings' id='test_connection' disabled>" . __( 'Test Connection', 'order-delivery-date' ) . "</a>";
-    }
     
     /**
      * Callback for adding the 'Add to Calendar' button in the New Order email notification

--- a/order-delivery-date-for-woocommerce/includes/settings/orddd-lite-settings.php
+++ b/order-delivery-date-for-woocommerce/includes/settings/orddd-lite-settings.php
@@ -600,14 +600,6 @@ class orddd_lite_settings {
         );
     
         add_settings_field(
-            'orddd_lite_calendar_test_connection',
-            '',
-            array( 'orddd_lite_calendar_sync_settings', 'orddd_lite_calendar_test_connection_callback' ),
-            'orddd_lite_calendar_sync_settings_page',
-            'orddd_lite_calendar_sync_admin_settings_section'
-        );
-    
-        add_settings_field(
             'orddd_lite_admin_add_to_calendar_delivery_calendar',
             __( 'Show "Export to Google Calendar" button on Delivery Calendar page', 'order-delivery-date' ),
             array( 'orddd_lite_calendar_sync_settings', 'orddd_lite_admin_add_to_calendar_delivery_calendar_callback' ),


### PR DESCRIPTION
Removed the Test Connection Link from the Google Calendar Sync tab as it was not required.