### PR TITLE
Version 3.9

### DIFF
--- a/order-delivery-date-for-woocommerce/order_delivery_date.php
+++ b/order-delivery-date-for-woocommerce/order_delivery_date.php
@@ -4,7 +4,7 @@ Plugin Name: Order Delivery Date for WooCommerce (Lite version)
 Plugin URI: https://www.tychesoftwares.com/store/premium-plugins/order-delivery-date-for-woocommerce-pro-21/
 Description: This plugin allows customers to choose their preferred Order Delivery Date during checkout.
 Author: Tyche Softwares
-Version: 3.8.1
+Version: 3.9
 Author URI: https://www.tychesoftwares.com/
 Contributor: Tyche Softwares, https://www.tychesoftwares.com/
 Text Domain: order-delivery-date
@@ -18,7 +18,7 @@ WC tested up to: 3.6.1
  * Latest version of the plugin
  * @since 1.0
  */
-$wpefield_version = '3.8.1';
+$wpefield_version = '3.9';
 
 /**
  * Include the require files
@@ -263,7 +263,7 @@ if ( !class_exists( 'order_delivery_date_lite' ) ) {
         
         function orddd_lite_update_db_check() {
             global $wpefield_version;
-            if ( $wpefield_version == "3.8.1" ) {
+            if ( $wpefield_version == "3.9" ) {
                 order_delivery_date_lite::orddd_lite_update_install();
             }
         }


### PR DESCRIPTION
3.9 (23.07.2019)
* Feature - You can now set a range of dates as holidays.
* Feature - You can now block the holidays for future years too. A checkbox named ‘Allow Recurring’ is added which if checked while adding holidays, it will disable the dates for all years in the calendar.
* Bug Fix -  Delivery Date calendar was not working on the checkout page with the Prohauz child theme. This is fixed now.
* Bug Fix - Number of dates available in the calendar was one less than the value set for the "Number of Dates to choose" option. This is fixed now.