### PR TITLE
Fix #241: fix the error coming in WP 5.5

### DIFF
--- a/order-delivery-date-for-woocommerce/includes/component/tracking-data/assets/js/dismiss-notice.js
+++ b/order-delivery-date-for-woocommerce/includes/component/tracking-data/assets/js/dismiss-notice.js
@@ -11,7 +11,7 @@ jQuery( document ).ready(
 				function() {
 					var $this = jQuery( this ),
 					$button   = jQuery( '<button type="button" class="notice-dismiss"><span class="screen-reader-text"></span></button>' ),
-					btnText   = commonL10n.dismiss || '';
+					btnText   = wp.i18n.dismiss || '';
 
 					// Ensure plain text
 					$button.find( '.screen-reader-text' ).text( btnText );

--- a/order-delivery-date-for-woocommerce/js/dismiss-notice.js
+++ b/order-delivery-date-for-woocommerce/js/dismiss-notice.js
@@ -11,7 +11,7 @@ jQuery( document ).ready(
 				function() {
 					var $this = jQuery( this ),
 					$button   = jQuery( '<button type="button" class="notice-dismiss"><span class="screen-reader-text"></span></button>' ),
-					btnText   = commonL10n.dismiss || '';
+					btnText   = wp.i18n.dismiss || '';
 
 					// Ensure plain text
 					$button.find( '.screen-reader-text' ).text( btnText );


### PR DESCRIPTION
A js error was coming in WP 5.5 for an undefined variable. 

[do-not-scan]