### PR TITLE
Fix #2481:Add the default value for time slot label

### DIFF
--- a/order-delivery-date-for-woocommerce/includes/orddd-lite-config.php
+++ b/order-delivery-date-for-woocommerce/includes/orddd-lite-config.php
@@ -105,6 +105,11 @@ $orddd_lite_date_formats = array(
 	'D, MM d, yy'  => 'D, F j, Y',
 );
 
+$orddd_lite_time_formats = array(
+	1 => '12 hour',
+	2 => '24 hour',
+);
+
 /**
  * Define the Number of months to be displayed in The Delivery Calendar
  *
@@ -255,6 +260,7 @@ $orddd_lite_languages = array(
  * @since 1.9
  */
 define( 'ORDDD_LITE_DELIVERY_DATE_FIELD_LABEL', 'Delivery Date' );
+define( 'ORDDD_LITE_DELIVERY_TIME_FIELD_LABEL', 'Time Slot' );
 define( 'ORDDD_LITE_DELIVERY_DATE_FIELD_PLACEHOLDER', 'Choose a Date' );
 define( 'ORDDD_LITE_DELIVERY_DATE_FIELD_NOTE', 'We will try our best to deliver your order on the specified date.' );
 define( 'ORDDD_LITE_DELIVERY_DATE_FORMAT', 'd MM, yy' );

--- a/order-delivery-date-for-woocommerce/uninstall.php
+++ b/order-delivery-date-for-woocommerce/uninstall.php
@@ -57,5 +57,14 @@ delete_option( 'orddd_lite_calendar_theme_name' );
 delete_option( 'orddd_lite_no_fields_for_virtual_product' );
 delete_option( 'orddd_lite_no_fields_for_featured_product' );
 
+// Delete Time slot options.
+delete_option( 'orddd_lite_enable_time_slot' );
+delete_option( 'orddd_lite_time_slot_mandatory' );
+delete_option( 'orddd_lite_time_slot_asap' );
+delete_option( 'orddd_lite_auto_populate_first_available_time_slot' );
+delete_option( 'orddd_lite_time_slot_mandatory' );
+delete_option( 'orddd_lite_delivery_time_slot_log' );
+delete_option( 'orddd_lite_lockout_time_slot' );
+
 // Delete holidays.
 delete_option( 'orddd_lite_holidays' );

--- a/order-delivery-date-for-woocommerce/uninstall.php
+++ b/order-delivery-date-for-woocommerce/uninstall.php
@@ -56,6 +56,8 @@ delete_option( 'orddd_lite_calendar_theme' );
 delete_option( 'orddd_lite_calendar_theme_name' );
 delete_option( 'orddd_lite_no_fields_for_virtual_product' );
 delete_option( 'orddd_lite_no_fields_for_featured_product' );
+delete_option( 'orddd_lite_delivery_timeslot_field_label' );
+
 
 // Delete Time slot options.
 delete_option( 'orddd_lite_enable_time_slot' );


### PR DESCRIPTION
Added a default value for time slot label and fixed the error for time slot formats. And delete the options while deleting the plugin.

Also Fixes #249 