### PR TITLE
Fix #248:Time slot label was coming blank on fresh install

### DIFF
--- a/order-delivery-date-for-woocommerce/includes/settings/class-orddd-lite-settings.php
+++ b/order-delivery-date-for-woocommerce/includes/settings/class-orddd-lite-settings.php
@@ -1362,11 +1362,6 @@ class Orddd_Lite_Settings {
 		<div class="wrap woocommerce">
 			<nav class="nav-tab-wrapper woo-nav-tab-wrapper" id="orddd_settings_tabs">
 				<a href="admin.php?page=order_delivery_date_lite&action=general_settings" class="nav-tab <?php echo esc_attr( $active_general_settings ); ?>"><?php esc_attr_e( 'General Settings', 'order-delivery-date' ); ?> </a>
-				<?php
-				if ( 'on' === get_option( 'orddd_enable_day_wise_settings' ) ) {
-					?>
-					<a href="admin.php?page=order_delivery_date_lite&action=advance_settings" class="nav-tab <?php echo esc_attr( $active_advance_settings ); ?>"> <?php esc_attr_e( 'Weekday Settings', 'order-delivery-date' ); ?> </a>
-				<?php } ?>
 				<a href="admin.php?page=order_delivery_date_lite&action=shipping_based" class="nav-tab <?php echo esc_attr( $active_shipping_based ); ?>"> <?php esc_attr_e( 'Custom Delivery Settings', 'order-delivery-date' ); ?> </a>
 				<a href="admin.php?page=order_delivery_date_lite&action=calendar_sync_settings" class="nav-tab <?php echo esc_attr( $calendar_sync_settings ); ?>"> <?php esc_attr_e( 'Google Calendar Sync', 'order-delivery-date' ); ?> 
 				</a>

--- a/order-delivery-date-for-woocommerce/order_delivery_date.php
+++ b/order-delivery-date-for-woocommerce/order_delivery_date.php
@@ -183,7 +183,7 @@ if ( ! class_exists( 'order_delivery_date_lite' ) ) {
 			// Appearance options.
 			add_option( 'orddd_lite_delivery_date_format', ORDDD_LITE_DELIVERY_DATE_FORMAT );
 			add_option( 'orddd_lite_delivery_date_field_label', ORDDD_LITE_DELIVERY_DATE_FIELD_LABEL );
-			add_option( 'orddd_lite_delivery_date_field_label', ORDDD_LITE_DELIVERY_TIME_FIELD_LABEL );
+			add_option( 'orddd_lite_delivery_timeslot_field_label', ORDDD_LITE_DELIVERY_TIME_FIELD_LABEL );
 			add_option( 'orddd_lite_delivery_date_field_placeholder', ORDDD_LITE_DELIVERY_DATE_FIELD_PLACEHOLDER );
 			add_option( 'orddd_lite_delivery_date_field_note', ORDDD_LITE_DELIVERY_DATE_FIELD_NOTE );
 			add_option( 'orddd_lite_number_of_months', '1' );


### PR DESCRIPTION
Time slot label was coming blank when plugin was activated for the first time