### PR TITLE
Fix #269:The date field placement was incorrect

### DIFF
--- a/order-delivery-date-for-woocommerce/includes/orddd-lite-config.php
+++ b/order-delivery-date-for-woocommerce/includes/orddd-lite-config.php
@@ -282,6 +282,8 @@ if ( get_option( 'orddd_lite_delivery_date_fields_on_checkout_page' ) === 'billi
 	define( 'ORDDD_LITE_SHOPPING_CART_HOOK', 'woocommerce_before_order_notes' );
 } elseif ( get_option( 'orddd_lite_delivery_date_fields_on_checkout_page' ) === 'after_order_notes' ) {
 	define( 'ORDDD_LITE_SHOPPING_CART_HOOK', 'woocommerce_after_order_notes' );
+} else if ( 'after_your_order_table' == get_option( 'orddd_lite_delivery_date_fields_on_checkout_page' ) ) {
+    define( 'ORDDD_LITE_SHOPPING_CART_HOOK', 'woocommerce_review_order_before_payment' );
 } elseif ( get_option( 'orddd_lite_date_in_shipping' ) === 'on' ) {
 	define( 'ORDDD_LITE_SHOPPING_CART_HOOK', 'woocommerce_after_checkout_shipping_form' );
 } else {

--- a/order-delivery-date-for-woocommerce/includes/orddd-lite-config.php
+++ b/order-delivery-date-for-woocommerce/includes/orddd-lite-config.php
@@ -282,8 +282,8 @@ if ( get_option( 'orddd_lite_delivery_date_fields_on_checkout_page' ) === 'billi
 	define( 'ORDDD_LITE_SHOPPING_CART_HOOK', 'woocommerce_before_order_notes' );
 } elseif ( get_option( 'orddd_lite_delivery_date_fields_on_checkout_page' ) === 'after_order_notes' ) {
 	define( 'ORDDD_LITE_SHOPPING_CART_HOOK', 'woocommerce_after_order_notes' );
-} elseif ( 'after_your_order_table' == get_option( 'orddd_lite_delivery_date_fields_on_checkout_page' ) ) {
-    define( 'ORDDD_LITE_SHOPPING_CART_HOOK', 'woocommerce_review_order_before_payment' );
+} elseif ( 'after_your_order_table' === get_option( 'orddd_lite_delivery_date_fields_on_checkout_page' ) ) {
+	define( 'ORDDD_LITE_SHOPPING_CART_HOOK', 'woocommerce_review_order_before_payment' );
 } elseif ( get_option( 'orddd_lite_date_in_shipping' ) === 'on' ) {
 	define( 'ORDDD_LITE_SHOPPING_CART_HOOK', 'woocommerce_after_checkout_shipping_form' );
 } else {

--- a/order-delivery-date-for-woocommerce/includes/orddd-lite-config.php
+++ b/order-delivery-date-for-woocommerce/includes/orddd-lite-config.php
@@ -282,7 +282,7 @@ if ( get_option( 'orddd_lite_delivery_date_fields_on_checkout_page' ) === 'billi
 	define( 'ORDDD_LITE_SHOPPING_CART_HOOK', 'woocommerce_before_order_notes' );
 } elseif ( get_option( 'orddd_lite_delivery_date_fields_on_checkout_page' ) === 'after_order_notes' ) {
 	define( 'ORDDD_LITE_SHOPPING_CART_HOOK', 'woocommerce_after_order_notes' );
-} else if ( 'after_your_order_table' == get_option( 'orddd_lite_delivery_date_fields_on_checkout_page' ) ) {
+} elseif ( 'after_your_order_table' == get_option( 'orddd_lite_delivery_date_fields_on_checkout_page' ) ) {
     define( 'ORDDD_LITE_SHOPPING_CART_HOOK', 'woocommerce_review_order_before_payment' );
 } elseif ( get_option( 'orddd_lite_date_in_shipping' ) === 'on' ) {
 	define( 'ORDDD_LITE_SHOPPING_CART_HOOK', 'woocommerce_after_checkout_shipping_form' );


### PR DESCRIPTION
When the field placement was selected as 'Between Your Order & Payment Section', the date field was still placed in the Billing section.