### PR TITLE
Version 3.11.1

### DIFF
--- a/order-delivery-date-for-woocommerce/order_delivery_date.php
+++ b/order-delivery-date-for-woocommerce/order_delivery_date.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://www.tychesoftwares.com/store/premium-plugins/order-delivery-date-for-woocommerce-pro-21/
  * Description: This plugin allows customers to choose their preferred Order Delivery Date during checkout.
  * Author: Tyche Softwares
- * Version: 3.11.0
+ * Version: 3.11.1
  * Author URI: https://www.tychesoftwares.com/
  * Contributor: Tyche Softwares, https://www.tychesoftwares.com/
  * Text Domain: order-delivery-date
@@ -20,7 +20,7 @@
  *
  * @since 1.0
  */
-$wpefield_version = '3.11.0';
+$wpefield_version = '3.11.1';
 
 /**
  * Include the require files
@@ -290,7 +290,7 @@ if ( ! class_exists( 'order_delivery_date_lite' ) ) {
 		 */
 		public function orddd_lite_update_db_check() {
 			global $wpefield_version;
-			if ( '3.11.0' === $wpefield_version ) {
+			if ( '3.11.1' === $wpefield_version ) {
 				self::orddd_lite_update_install();
 			}
 		}

--- a/order-delivery-date-for-woocommerce/readme.txt
+++ b/order-delivery-date-for-woocommerce/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://www.paypal.me/TycheSoftwares
 Author URI: https://www.tychesoftwares.com/
 Tags: delivery date, delivery time, preparation time, woocommerce, pickup date
 Requires at least: 1.3
-Tested up to: 5.5
+Tested up to: 5.5.1
 Stable tag: trunk
 Requires PHP: 5.6
 License: GPLv2 or later
@@ -242,6 +242,10 @@ Currently, it is not possible to add different delivery settings for different s
 6. Holidays tab
 
 == Changelog ==
+
+= 3.11.1 (04.09.2020) =
+* Fix - 'Array' word was being displayed in the order emails.
+* Fix - The delivery date field was not placed correctly when the setting 'Field placement on the Checkout page' was set to 'Between Your Order & Payment Section'.
 
 = 3.11.0 (01.09.2020) =
 * Feature - Ability to add time slots for weekdays. You can now add time slots with maximum order deliveries per time slot, time slot charges.


### PR DESCRIPTION
* Fix - 'Array' word was being displayed in the order emails.
* Fix - The delivery date field was not placed correctly when the setting 'Field placement on the Checkout page' was set to 'Between Your Order & Payment Section'.