### PR TITLE
Minimum delivery time was not applied on disabled days even if the setting was enabled

### DIFF
--- a/includes/class-orddd-lite-common.php
+++ b/includes/class-orddd-lite-common.php
@@ -901,7 +901,7 @@ class Orddd_Lite_Common {
 		if ( 0 != $delivery_time_seconds && '' != $delivery_time_seconds ) { //phpcs:ignore
 			$calculate_min = true;
 		}
-
+		$apply_disabled_weekdays = get_option( 'orddd_lite_calculate_min_time_disabled_days' );
 		// Min Date calculation.
 		if ( $calculate_min ) {
 			$cut_off_timestamp = $current_time + $delivery_time_seconds;
@@ -917,7 +917,7 @@ class Orddd_Lite_Common {
 						$weekday_disabled = 'yes';
 					}
 
-					if ( 'yes' === $weekday_disabled && ! $is_all_disable_weekdays ) {
+					if ( 'on' !== $apply_disabled_weekdays && 'yes' === $weekday_disabled && ! $is_all_disable_weekdays ) {
 						$current_date_time_to_check = strtotime( '+1 day', $current_date_time_to_check );
 						$current_weekday_to_check   = date( 'w', $current_date_time_to_check ); //phpcs:ignore
 

--- a/includes/class-orddd-lite-process.php
+++ b/includes/class-orddd-lite-process.php
@@ -253,11 +253,6 @@ class Orddd_Lite_Process {
 			<input type="hidden" name="orddd_lite_auto_populate_first_available_date" id="orddd_lite_auto_populate_first_available_date" value="<?php echo esc_attr( get_option( 'orddd_lite_auto_populate_first_available_date' ) ); ?>">
 			<input type="hidden" name="orddd_lite_calculate_min_time_disabled_days" id="orddd_lite_calculate_min_time_disabled_days" value="<?php echo esc_attr( get_option( 'orddd_lite_calculate_min_time_disabled_days' ) ); ?>">
 			<?php
-
-			$current_date = gmdate( 'j-n-Y', $current_time );
-			?>
-			<input type="hidden" name="orddd_lite_current_day" id="orddd_lite_current_day" value="<?php echo esc_attr( $current_date ); ?>">
-			<?php
 			$admin_url     = get_admin_url();
 			$admin_url_arr = explode( '://', $admin_url );
 			$home_url      = get_home_url();

--- a/js/orddd-lite-initialize-datepicker.js
+++ b/js/orddd-lite-initialize-datepicker.js
@@ -497,13 +497,14 @@ function avd( date ) {
 
 	if ( delay_date != "" ) {
 		var delay_time      = delay_days.getTime();
+		var delay_weekday   = delay_days.getDay();
 		var current_time    = current_day.getTime();
 		var current_weekday = current_day.getDay();
 		var j;
 		for ( j = current_weekday; current_time <= delay_time; j++ ) {
 			if ( j >= 0 ) {
 				if ( jQuery( "#orddd_lite_calculate_min_time_disabled_days" ).val() != 'on' ) {
-					day       = 'orddd_lite_weekday_' + current_weekday;
+					day       = 'orddd_lite_weekday_' + delay_weekday;
 					day_check = jQuery( "#" + day ).val();
 					if ( day_check == '' ) {
 						delay_days.setDate( delay_days.getDate() + 1 );


### PR DESCRIPTION
The 'Apply Minimum Delivery Time for non working weekdays' setting was not working correctly. The disabled weekdays were not considered when calculating the min date.

Fix #274 